### PR TITLE
Convert more \URL tags to \DOI in R Markdown files

### DIFF
--- a/man/TIMP-package.Rd
+++ b/man/TIMP-package.Rd
@@ -12,12 +12,12 @@ Maintainer: Joris J. Snellenburg \email{j.snellenburg@vu.nl}
 \references{
   Mullen KM, van Stokkum IHM (2007). ``TIMP: An R Package for Modeling
   Multi-way Spectroscopic Measurements.'' Journal of Statistical
-  Software, 18(3). URL \url{https://doi.org/10.18637/jss.v018.i03}.
+  Software, 18(3). \doi{10.18637/jss.v018.i03}.
 
   Laptenok S, Mullen KM, Borst JW, van Stokkum IHM, Apanasovich VV,
   Visser AJWG (2007). ``Fluorescence Lifetime Imaging Microscopy (FLIM)
   Data Analysis with TIMP.''  Journal of Statistical Software,
-  18(8). URL \url{https://doi.org/10.18637/jss.v018.i08}.
+  18(8). \doi{10.18637/jss.v018.i08}.
 
   See \url{https://glotaran.github.io/TIMP/} for further documentation.
 }

--- a/man/denS4.Rd
+++ b/man/denS4.Rd
@@ -20,7 +20,7 @@ data("denS5")
 Mullen KM, van Stokkum IHM (2007).
 TIMP: An R Package for Modeling Multi-way Spectroscopic
 Measurements. \emph{Journal of Statistical Software}, \bold{18}(3),
-\url{https://doi.org/10.18637/jss.v018.i03}.
+\doi{10.18637/jss.v018.i03}.
 }
 \examples{
 data("denS4")

--- a/man/fitModel.Rd
+++ b/man/fitModel.Rd
@@ -152,7 +152,7 @@ is returned as an array of strings}
 \references{Mullen KM, van Stokkum IHM (2007).
 ``TIMP: an R package for modeling
 multi-way spectroscopic measurements.'' Journal of Statistical Software,
-18(3). \url{https://doi.org/10.18637/jss.v018.i03}}
+18(3). \doi{10.18637/jss.v018.i03}}
 \author{Katharine M. Mullen, Ivo H. M. van Stokkum}
 \examples{
 


### PR DESCRIPTION
As suggested by CRAN's checks (`R CMD check --as-cran`)

This expands on the earlier conversion of some of the \URL s linking to doi.org to \doi, now also including the use in \reference.